### PR TITLE
Fix: allow conda builds with Python 3.5 (#56)

### DIFF
--- a/conda-recipe-openblas/bld.bat
+++ b/conda-recipe-openblas/bld.bat
@@ -8,7 +8,13 @@ RD /S /Q _skbuild
 set BLAS_ROOT=%PREFIX%
 set LAPACK_ROOT=%PREFIX%
 set NUMPY_INCLUDE=%PREFIX%\Include
-set F2PY=%PREFIX%\Scripts\f2py.exe
+:: Prefer f2py.exe, if it exists; this is provided by numpy 1.16 (and, we assume, later)
+if EXIST "%PREFIX%\Scripts\f2py.exe" (
+  set F2PY=%PREFIX%\Scripts\f2py.exe
+) ELSE (
+:: Otherwise use f2py.bat, which is provided by numpy 1.15 and earlier
+  set F2PY=%PREFIX%\Scripts\f2py.bat
+)
 
 "%PYTHON%" setup.py install
 

--- a/conda-recipe-openblas/meta.yaml
+++ b/conda-recipe-openblas/meta.yaml
@@ -12,7 +12,7 @@ build:
 requirements:
   build:
     - python {{ PY_VER }}
-    - numpy >=1.16
+    - numpy
     - openblas >=0.3.0
     - {{ compiler('c') }}       # [not osx]
     - gcc                       # [osx]
@@ -22,7 +22,7 @@ requirements:
   host:
     - python {{ PY_VER }}
     - flang                     # [win]
-    - numpy >=1.16
+    - numpy
     - openblas >=0.3.0
     - libgfortran-ng # [not-win]
     - libgcc-ng      # [linux]
@@ -33,7 +33,7 @@ requirements:
    
   run:
     - python {{ PY_VER }}
-    - numpy >=1.16
+    - {{ pin_compatible('numpy') }}
     - openblas >=0.3.0
     - libgfortran-ng # [not win]
     - libgcc-ng      # [linux]

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -8,7 +8,13 @@ RD /S /Q _skbuild
 set BLAS_ROOT=%PREFIX%
 set LAPACK_ROOT=%PREFIX%
 set NUMPY_INCLUDE=%PREFIX%\Include
-set F2PY=%PREFIX%\Scripts\f2py.exe
+:: Prefer f2py.exe, if it exists; this is provided by numpy 1.16 (and, we assume, later)
+if EXIST "%PREFIX%\Scripts\f2py.exe" (
+  set F2PY=%PREFIX%\Scripts\f2py.exe
+) ELSE (
+:: Otherwise use f2py.bat, which is provided by numpy 1.15 and earlier
+  set F2PY=%PREFIX%\Scripts\f2py.bat
+)
 
 "%PYTHON%" setup.py install
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   # conda-forge might have the configuration in place for clang build and link?
   build:
     - python {{PY_VER}}
-    - numpy >=1.16
+    - numpy
     - {{ compiler('c') }}       # [not osx]
     - gcc                       # [osx]
     - {{ compiler('fortran') }} # [linux]
@@ -25,7 +25,7 @@ requirements:
   host:
     - python {{ PY_VER }}
     - flang                     # [win]
-    - numpy >=1.16
+    - numpy
     - mkl
     - libgfortran-ng # [not win]
     - libgcc-ng      # [linux]
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - python {{ PY_VER }}
-    - numpy >=1.16
+    - {{ pin_compatible('numpy') }}
     - mkl
     - libgfortran-ng # [not win]
     - libgcc-ng      # [linux]


### PR DESCRIPTION
Use f2py.exe for F2PY if it exists; this is the case for Numpy 1.16, which has been packaged for Python 3.6 and 3.7 in conda or conda-forge.

If f2py.exe is not found, use f2py.bat; this is the case for Numpy 1.15, which has been pacakge for Python 3.5.

Use pin_compatible for numpy version requirements; at time of this check-in, this builds against Numpy 1.9.3 on Linux, but tests against 1.16.